### PR TITLE
ci: Removed deprecated set-output usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       # so we use this workaround https://github.com/actions/setup-node/issues/488
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
         uses: actions/cache@v3

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,7 +23,7 @@ jobs:
       # so we use this workaround https://github.com/actions/setup-node/issues/488
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
         shell: bash
       - name: Restore yarn cache
         uses: actions/cache@v3


### PR DESCRIPTION
- [ ] I have added automatic tests where applicable
- [x] The PR title is suitable as a release note
- [x] The PR contains a description of what has been changed
- [x] The description contains manual test instructions

## Changes

`set-output` has been [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) in github actions. This changes the actions to use the new environment files.

## Test

Examine that the actions still work as intended
